### PR TITLE
Added functionality to assert_equal independent of the order

### DIFF
--- a/src/sql_mock/table_mocks.py
+++ b/src/sql_mock/table_mocks.py
@@ -123,7 +123,7 @@ class BaseMockTable:
             snippet = "\nUNION ALL\nSELECT ".join([self._to_sql_row(row_data) for row_data in self._data])
         return f"SELECT {snippet}"
 
-    def assert_equal(self, expected: [dict], ignore_missing_keys=False):
+    def assert_equal(self, expected: [dict], ignore_missing_keys: bool = False, ignore_order: bool = True):
         """
         Assert that the class data matches the expected data.
 
@@ -133,9 +133,13 @@ class BaseMockTable:
             expected (list of dicts): Expected data to compare the class data against
             ignore_missing_keys (bool): If true, the comparison will only happen for the fields that are present in the
                 list of dictionaries of the `expected` argument.
+            ignore_order (bool): If true, the order of dicts / rows will be ignored for comparison.
         """
         data = self._data
         if ignore_missing_keys:
             keys_to_keep = set(key for dictionary in expected for key in dictionary.keys())
             data = [{key: value for key, value in dictionary.items() if key in keys_to_keep} for dictionary in data]
+        if ignore_order:
+            data = sorted(data, key=lambda d: sorted(d.items()))
+            expected = sorted(expected, key=lambda d: sorted(d.items()))
         assert expected == data

--- a/tests/sql_mock/test_table_mocks.py
+++ b/tests/sql_mock/test_table_mocks.py
@@ -169,6 +169,18 @@ def test_assert_equal_with_ignored_missing_keys():
     data_instance.assert_equal(expected_data, ignore_missing_keys=True)
 
 
+def test_assert_equal_dict_ordering_differs_key_order_matches(base_mock_table_instance):
+    expected_data = [{"column1": 1, "column2": "value1"}, {"column1": 2, "column2": "value2"}]
+    base_mock_table_instance._data = [{"column1": 2, "column2": "value2"}, {"column1": 1, "column2": "value1"}]
+    base_mock_table_instance.assert_equal(expected_data)
+
+
+def test_assert_equal_dict_ordering_differs_key_order_differs(base_mock_table_instance):
+    expected_data = [{"column1": 1, "column2": "value1"}, {"column1": 2, "column2": "value2"}]
+    base_mock_table_instance._data = [{"column1": 2, "column2": "value2"}, {"column2": "value1", "column1": 1}]
+    base_mock_table_instance.assert_equal(expected_data)
+
+
 def test_assert_equal_with_non_matching_data():
     # Arrange
     data_instance = TestData([{"name": "Alice", "age": 25}, {"name": "Bob", "age": 30}])


### PR DESCRIPTION
# Problem

Currently, when calling `.assert_equal`, we always depend on the order of "rows" in the list of dictionaries.
We should have the ability to also compare ignoring the order

# What changed
* Added a new function parameter `ignore_order` which is True by default