### PR TITLE
Added functionality to pass the query_path via the table_meta decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2] - 2023-10-26
 Initial version.
 
-[Unreleased]: https://github.com/DeepLcom/deepl-python/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/DeepLcom/sql-mock/compare/v0.1.2...HEAD
 [0.1.2]: https://github.com/DeepLcom/sql-mock/releases/tag/v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 
+
+### Added 
+
+- Possibility to pass the `query_path` in the `table_meta` decorator. This allows to specify the query of a model in a single place instead of always needing to pass it in the `from_mocks` method. The provided query can still be overwritten in `from_mocks` if necessary
+
+### Changed
+
+- Using `_sql_mock_meta` and `_sql_mock_data` attributes on `BaseMockTable` to decrease that chance of interference with the model's column names
 
 ## [0.1.2] - 2023-10-26
 Initial version.
 
-
-[0.1.2]: https://github.com/DeepLcom/sql-mock/releases/tag/v0.1.0
+[Unreleased]: https://github.com/DeepLcom/deepl-python/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/DeepLcom/sql-mock/releases/tag/v0.1.2

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Before diving into specific database scenarios, let's start with a simplified ex
 
 ### Defining your table mocks
 
-When you want to provide mocked data to test your SQL model, you need to create MockTable classes for all upstream input data, as well as for the model you want to test. Those mock tables can be created by inheriting from a `BaseMockTable` class for the database provider you are using (e.g. `BigQueryMockTable`).
+When you want to provide mocked data to test your SQL model, you need to create MockTable classes for all upstream data that your model uses, as well as for the model you want to test. Those mock tables can be created by inheriting from a `BaseMockTable` class for the database provider you are using (e.g. `BigQueryMockTable`).
 
 **We recommend to have a central `model.py` file where you create those models that you can easily reuse them across your tests**
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Before diving into specific database scenarios, let's start with a simplified ex
 
 1. You have an original SQL query, for instance:
    ```sql
+   -- path/to/query_for_result_table.sql
    SELECT id FROM data.table1
    ```
 
@@ -52,12 +53,12 @@ Before diving into specific database scenarios, let's start with a simplified ex
     from sql_mock.clickhouse import column_mocks as col
     from sql_mock.clickhouse.table_mocks import ClickHouseTableMock, table_meta
 
-    @table_meta(table_ref='data.table1)
+    @table_meta(table_ref='data.table1')
     class Table(ClickHouseTableMock):
         id = col.Int(default=1)
         name = col.String(default='Peter')
     
-    @table_meta(table_ref='data.result_table')
+    @table_meta(table_ref='data.result_table', query_path='path/to/query_for_result_table.sql')
     class ResultTable(ClickhouseTableMock):
         id = col.Int(default=1)
     ```
@@ -74,9 +75,9 @@ Before diving into specific database scenarios, let's start with a simplified ex
     ```
 
 
-4. **Getting results for a table mock:** Use the `from_inputs` method of the table mock object to generate mock query results based on your mock data.
+4. **Getting results for a table mock:** Use the `from_mocks` method of the table mock object to generate mock query results based on your mock data.
     ```python
-    res = ResultTable.from_mocks(query='SELECT id FROM data.table1', input_data=[input_table_mock])
+    res = ResultTable.from_mocks(input_data=[input_table_mock])
     ```
 
 5. Behind the scene SQL Mock replaces table references (e.g. `data.table1`) in your query with Common Table Expressions (CTEs) filled with dummy data. It can roughly be compared to something like this:
@@ -112,7 +113,47 @@ Before diving into specific database scenarios, let's start with a simplified ex
     res.assert_equal(expected)
     ```
 
-### Setup for Pytest
+### Defining your table mocks
+
+When you want to provide mocked data to test your SQL model, you need to create MockTable classes for all upstream input data, as well as for the model you want to test. Those mock tables can be created by inheriting from a `BaseMockTable` class for the database provider you are using (e.g. `BigQueryMockTable`).
+
+**We recommend to have a central `model.py` file where you create those models that you can easily reuse them across your tests**
+
+```python
+# models.py
+
+from sql_mock.bigquery import column_mocks as col
+from sql_mock.bigquery.table_mocks import BigQueryMockTable, table_meta
+
+# The models you are goign to use as inputs need to have a `table_ref` specified
+@table_meta(table_ref='data.table1')
+class Table(BigQueryMockTable):
+    id = col.Int(default=1)
+    name = col.String(default='Peter')
+
+@table_meta(table_ref='data.result_table', query_path='path/to/query_for_result_table.sql')
+class ResultTable(BigQueryMockTable):
+    id = col.Int(default=1)
+```
+
+Some important things to mention:
+
+#### The models you are goign to use as inputs need to have a `table_ref` specified. 
+The `table_ref` is how the table will be referenced in your production database (usually some pattern like `<schema>.<table>`)
+
+#### The model needs to have a query. 
+There are currently 2 ways to provide a query to the model: 
+
+1. Pass a path to your query file in the class definition using the `table_meta` decorator. This allows us to only specify it once.   
+    ```python
+    @table_meta(table_ref='data.result_table', query_path='path/to/query_for_result_table.sql')
+    class ResultTable(BigQueryMockTable):
+        ...
+    ```
+2. Pass it as `query` argument to the `from_mocks` method when you are using the model in your test. This will also overwrite whatever query was read from the `query_path` in the `table_meta` decorator.
+
+
+### Recommended Setup for Pytest
 If you are using pytest, make sure to add a `conftest.py` file to the root of your project.
 In the file add the following lines:
 ```python
@@ -125,6 +166,69 @@ We also recommend using [pytest-icdiff](https://github.com/hjwp/pytest-icdiff) f
 
 ### Examples
 You can find some examples in the [examples folder](examples/).
+
+
+## FAQ
+
+### My database system is not supported yet but I want to use SQL Mock. What should I do?
+
+We are planning to add more and more supported database systems. However, if your system is not supported yet, you can still use SQL Mock. There are only 2 things you need to do:
+
+#### Create your `MockTable` class 
+
+First, you need to create a `MockTable` class for your database system that inherits from `sql_mock.table_mocks.BaseMockTable`.
+
+That class needs to implement the `_get_results` method which should make sure to fetch the results of a query (e.g. produced by `self._generate_query()`) and return it as list of dictionaries.
+
+Look at one of the existing client libraries to see how this could work (e.g. [BigQueryMockTable](https://github.com/DeepLcom/sql-mock/blob/main/src/sql_mock/bigquery/table_mocks.py)).
+
+You might want to create a settings class as well in case you need some specific connection settings to be available within the `_get_results` method.
+
+#### Create your `ColumnMocks`
+
+Your database system might support specific database types. In order to make them available as column types, you can use the `sql_mock.column_mocks.ColumnMock` class as a base and inherit your specific column types from it.
+For most of your column mocks you might only need to specify the `dtype` that should be used to parse the inputs.
+
+A good practise is to create a `ColumnMock` class that is specific to your database and inherit all your column types from it, e.g.:
+
+```python
+from sql_mock.column_mocks import ColumnMock
+
+class MyFanceDatabaseColumnMock(ColumnMock):
+    # In case you need some specific logic that overwrites the default behavior, you can do so here
+    pass 
+
+class Int(MyFanceDatabaseColumnMock):
+    dtype = "Integer"
+
+class String(MyFanceDatabaseColumnMock):
+    dtype = "String"
+```
+
+#### Contribute your database setup
+
+There will definitely be folks in the community that are in the need of support for the database you just created all the setup for.
+Feel free to create a PR on this repository that we can start supporting your database system!
+
+
+### I am missing a specific ColumnMock type for my model fields
+
+We implementd some basic column types but it could happen that you don't find the one you need. 
+Luckily, you can easily create those with the tools provided.
+The only thing you need to do is to inherit from the `ColumnMock` that is specific to your database system (e.g. `BigQueryColumnMock`) and write classes for the column mocks you are missing. Usually you only need to set the correct `dtype`. This would later be used in the `cast(col to <dtype>)` expression.
+
+```python
+# Replace the import with the database system you are using
+from sql_mock.bigquery.column_mock import BigQueryColumnMock 
+
+class MyFancyMissingColType(BigQueryColumnMock):
+    dtype = "FancyMissingColType"
+
+    # In case you need to implement additional logic for casting, you can do so here
+    ...
+```
+
+**Don't forget to create a PR in case you feel that your column mock type could be useful for the community**!
 
 
 ## Contributing

--- a/examples/bigquery/test_example.py
+++ b/examples/bigquery/test_example.py
@@ -4,15 +4,6 @@ from sql_mock.bigquery import column_mocks as col
 from sql_mock.bigquery.table_mocks import BigQueryMockTable
 from sql_mock.table_mocks import table_meta
 
-query = """
-SELECT
-    count(*) AS subscription_count,
-    user_id
-FROM data.users
-LEFT JOIN data.subscriptions USING(user_id)
-GROUP BY user_id
-"""
-
 
 @table_meta(table_ref="data.users")
 class UserTable(BigQueryMockTable):
@@ -28,6 +19,7 @@ class SubscriptionTable(BigQueryMockTable):
     user_id = col.Int(default=1)
 
 
+@table_meta(query_path="./examples/test_query.sql")
 class SubscriptionCountTable(BigQueryMockTable):
     subscription_count = col.Int(default=1)
     user_id = col.Int(default=1)
@@ -45,6 +37,6 @@ def test_something():
 
     expected = [{"user_id": 1, "subscription_count": 2}, {"user_id": 2, "subscription_count": 1}]
 
-    res = SubscriptionCountTable.from_mocks(query=query, input_data=[users, subscriptions])
+    res = SubscriptionCountTable.from_mocks(input_data=[users, subscriptions])
 
     res.assert_equal(expected)

--- a/examples/clickhouse/test_example.py
+++ b/examples/clickhouse/test_example.py
@@ -4,15 +4,6 @@ from sql_mock.clickhouse import column_mocks as col
 from sql_mock.clickhouse.table_mocks import ClickHouseTableMock
 from sql_mock.table_mocks import table_meta
 
-query = """
-SELECT
-    count(*) AS subscription_count,
-    user_id
-FROM data.users
-LEFT JOIN data.subscriptions USING(user_id)
-GROUP BY user_id
-"""
-
 
 @table_meta(table_ref="data.users")
 class UserTable(ClickHouseTableMock):
@@ -28,6 +19,7 @@ class SubscriptionTable(ClickHouseTableMock):
     user_id = col.Int(default=1)
 
 
+@table_meta(query_path="./examples/test_query.sql")
 class SubscriptionCountTable(ClickHouseTableMock):
     subscription_count = col.Int(default=1)
     user_id = col.Int(default=1)
@@ -45,6 +37,6 @@ def test_something():
 
     expected = [{"user_id": 2, "subscription_count": 1}, {"user_id": 1, "subscription_count": 2}]
 
-    res = SubscriptionCountTable.from_mocks(query=query, input_data=[users, subscriptions])
+    res = SubscriptionCountTable.from_mocks(input_data=[users, subscriptions])
 
     res.assert_equal(expected)

--- a/examples/test_query.sql
+++ b/examples/test_query.sql
@@ -1,0 +1,6 @@
+SELECT
+    count(*) AS subscription_count,
+    user_id
+FROM data.users
+LEFT JOIN data.subscriptions USING(user_id)
+GROUP BY user_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ packages = [
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/DeepLcom/sql-mock/issues"
+"Changelog" = "https://github.com/DeepLcom/sql-mock/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/src/sql_mock/table_mocks.py
+++ b/src/sql_mock/table_mocks.py
@@ -20,16 +20,24 @@ class MockTableMeta(BaseModel):
 
     Attributes:
         table_ref (string) : String that represents the table reference to the original table.
+        query (string): Srting of the SQL query (can be in Jinja format).
     """
 
     table_ref: str = None
+    query: str = None
 
 
-def table_meta(table_ref):
+def table_meta(table_ref: str = "", query_path: str = None):
     """Decorator that is used to define MockTable metadata"""
 
     def decorator(cls):
-        cls._sql_mock_meta = MockTableMeta(table_ref=table_ref)
+        mock_meta_kwargs = {"table_ref": table_ref}
+
+        if query_path:
+            with open(query_path) as f:
+                mock_meta_kwargs["query"] = f.read()
+
+        cls._sql_mock_meta = MockTableMeta(**mock_meta_kwargs)
         return cls
 
     return decorator
@@ -105,11 +113,21 @@ class BaseMockTable:
         return cls(data=data)
 
     @classmethod
-    def from_mocks(cls, query, input_data: list["BaseMockTable"] = None, query_template_kwargs: dict = None):
+    def from_mocks(
+        cls, input_data: list["BaseMockTable"] = None, query_template_kwargs: dict = None, query: str = None
+    ):
+        """
+        Instantiate the mock table from input mocks. This runs the tables query with static data provided by the input mocks.
+
+        Arguments:
+            input_data: List of MockTable instances that hold static data that should be used as inputs.
+            query_template_kwargs: Dictionary of Jinja template key-value pairs that should be used to render the query.
+            query: String of the SQL query that is used to generate the model. Can be a Jinja template. If provided, it overwrites the query on cls._sql_mock_meta.query.
+        """
         validate_input_mocks(input_data)
 
         instance = cls(data=[])
-        query_template = Template(query)
+        query_template = Template(query or cls._sql_mock_meta.query)
 
         # Assign instance attributes
         instance._sql_mock_data.input_data = input_data

--- a/src/sql_mock/table_mocks.py
+++ b/src/sql_mock/table_mocks.py
@@ -244,6 +244,3 @@ class BaseMockTable:
             data = sorted(data, key=lambda d: sorted(d.items()))
             expected = sorted(expected, key=lambda d: sorted(d.items()))
         assert expected == data
-
-    class _sql_mock_meta(MockTableMeta):
-        pass

--- a/tests/sql_mock/test_table_meta.py
+++ b/tests/sql_mock/test_table_meta.py
@@ -1,0 +1,38 @@
+from sql_mock.table_mocks import BaseMockTable, table_meta
+
+
+def test_query_path_provided(mocker):
+    """...then the query should be read from the path and the result most be stored on the cls._sql_mock_meta"""
+    query = "SELECT bar FROM foo"
+    query_path = "some_path"
+    mock_open = mocker.patch("builtins.open")
+    # Configure the mock to return the file content
+    mock_open.return_value.__enter__.return_value.read.return_value = query
+
+    @table_meta(table_ref="", query_path=query_path)
+    class TestMock(BaseMockTable):
+        pass
+
+    assert TestMock._sql_mock_meta.query == query
+    mock_open.assert_called_with(query_path)
+
+
+def test_no_query_path_provided():
+    """...then there should not be any query string stored on the cls._sql_mock_meta"""
+
+    @table_meta(table_ref="")
+    class TestMock(BaseMockTable):
+        pass
+
+    assert TestMock._sql_mock_meta.query is None
+
+
+def test_table_ref_provided():
+    """...then the table_ref should be stored on the cls._sql_mock_meta"""
+    table_ref = "some.table"
+
+    @table_meta(table_ref=table_ref)
+    class TestMock(BaseMockTable):
+        pass
+
+    assert TestMock._sql_mock_meta.table_ref == table_ref

--- a/tests/sql_mock/test_table_mocks.py
+++ b/tests/sql_mock/test_table_mocks.py
@@ -57,7 +57,9 @@ def test_from_inputs(mocker, base_mock_table_instance):
     # Mock the _get_results method to return a simple list of dicts
     expected_results = [{"column1": 1, "column2": "value1"}, {"column1": 2, "column2": "value2"}]
     mocker.patch.object(BaseMockTable, "_get_results", return_value=expected_results)
-    instance = MockTestTable.from_mocks(query, input_data, query_template_kwargs)
+    instance = MockTestTable.from_mocks(
+        query=query, input_data=input_data, query_template_kwargs=query_template_kwargs
+    )
 
     assert isinstance(instance, MockTestTable)
     assert isinstance(instance._sql_mock_data.input_data, list)


### PR DESCRIPTION
# Problem

Right now you need to pass the query with each `from_mocks` call. 
This is very verbose and repetitive.

# What changed 
* Added new functionality to pass the `query_path` in the `table_metadata`. This allows to only pass the query definition (or its path) once. You can still overwrite it by passing a concrete `query` in the `from_mocks` method
* Added the changes to the CHANGELOG and README
* Bonus: Improved README and added a small FAQ