### PR TITLE
Use sqlglot to replace table reference

### DIFF
--- a/tests/test_table_mocks/test_generate_query.py
+++ b/tests/test_table_mocks/test_generate_query.py
@@ -30,7 +30,8 @@ def test_replace_original_table_references_when_reference_exists():
     """...then the original table reference should be replaced with the mocked table reference"""
     query = f"SELECT * FROM {MockTestTable._sql_mock_meta.table_ref}"
     mock_tables = [MockTestTable()]
-    expected = "SELECT * FROM data__mock_test_table"
+    # Note that sqlglot will add a comment with the original table name at the end
+    expected = "SELECT * FROM data__mock_test_table /* data.mock_test_table */"
     assert expected == replace_original_table_references(query, mock_tables)
 
 
@@ -135,7 +136,7 @@ def test_generate_query_no_cte_provided(mocker):
     # Asserts
     mocked_select_from_cte.assert_not_called()
     mocked_replace_original_table_references.assert_called_once_with(
-        expected_query_template_result, mock_tables=[mock_table_instance]
+        expected_query_template_result, mock_tables=[mock_table_instance], dialect=mock_table_instance._sql_dialect
     )
     # The final query should be equal to whatever is returned by `replace_original_table_references`
     assert query == mocked_replace_original_table_references.return_value
@@ -181,7 +182,7 @@ def test_generate_query_cte_provided(mocker):
         original_query, cte_to_select, sql_dialect=MockTestTable._sql_dialect
     )
     mocked_replace_original_table_references.assert_called_once_with(
-        expected_query_template_result, mock_tables=[mock_table_instance]
+        expected_query_template_result, mock_tables=[mock_table_instance], dialect=mock_table_instance._sql_dialect
     )
     # The final query should be equal to whatever is returned by `replace_original_table_references`
     assert query == mocked_replace_original_table_references.return_value


### PR DESCRIPTION
#Problem 

So far we have been using string replacement to replace the table references in the original query.
This can lead to unexpected behaviour and reduces our flexibility for future enhancements (e.g. checking whether all table references have actually been replaced).

# What changed

We use sqlglot now to replace the table references.