### PR TITLE
Use sqlglot for table ref replace

### DIFF
--- a/src/sql_mock/table_mocks.py
+++ b/src/sql_mock/table_mocks.py
@@ -4,6 +4,7 @@ from typing import List, Type
 import sqlglot
 from jinja2 import Template
 from pydantic import BaseModel, ConfigDict, SkipValidation
+from sqlglot.expressions import replace_tables
 
 from sql_mock.column_mocks import ColumnMock
 from sql_mock.constants import NO_INPUT
@@ -14,7 +15,7 @@ def get_keys_from_list_of_dicts(data: list[dict]) -> set[str]:
     return set(key for dictionary in data for key in dictionary.keys())
 
 
-def replace_original_table_references(query: str, mock_tables: list["BaseMockTable"]):
+def replace_original_table_references(query: str, mock_tables: list["BaseMockTable"], dialect: str = None):
     """
     Replace orignal table references to point them to the mocked data
 
@@ -22,10 +23,10 @@ def replace_original_table_references(query: str, mock_tables: list["BaseMockTab
         query (str): Original SQL query
         mock_tables (list[BaseMockTable]): List of BaseMockTable instances that are used as input
     """
-    for mock_table in mock_tables:
-        new_reference = mock_table._sql_mock_meta.table_ref.replace(".", "__")
-        query = query.replace(mock_table._sql_mock_meta.table_ref, new_reference)
-    return query
+    ast = sqlglot.parse_one(query, dialect=dialect)
+    mapping = {mock_table._sql_mock_meta.table_ref: mock_table.cte_name for mock_table in mock_tables}
+    res = replace_tables(expression=ast, mapping=mapping, dialect=dialect).sql(pretty=True, dialect=dialect)
+    return res
 
 
 def select_from_cte(query: str, cte_name: str, sql_dialect: str):
@@ -175,6 +176,12 @@ class BaseMockTable:
 
         self._sql_mock_data.data = [] if data is None else data
 
+    @property
+    def cte_name(self):
+        mock_meta = self._sql_mock_meta
+        if getattr(mock_meta, "table_ref", None):
+            return self._sql_mock_meta.table_ref.replace(".", "__")
+
     @classmethod
     def from_dicts(cls, data: list[dict] = None):
         return cls(data=data)
@@ -249,7 +256,9 @@ class BaseMockTable:
             final_columns_to_select=indent(final_columns_to_select, "\t"),
         )
 
-        query = replace_original_table_references(query, mock_tables=self._sql_mock_data.input_data)
+        query = replace_original_table_references(
+            query, mock_tables=self._sql_mock_data.input_data, dialect=self._sql_dialect
+        )
         # Store last query for debugging
         self._sql_mock_data.last_query = query
         return query
@@ -296,7 +305,7 @@ class BaseMockTable:
 
         # Indent whole CTE content for better query readability
         snippet = indent(f"SELECT {snippet}", "\t")
-        return f"{self._sql_mock_meta.table_ref} AS (\n{snippet}\n)"
+        return f"{self.cte_name} AS (\n{snippet}\n)"
 
     def _assert_equal(
         self, data: [dict], expected: [dict], ignore_missing_keys: bool = False, ignore_order: bool = True

--- a/tests/test_table_mocks/test_generate_query.py
+++ b/tests/test_table_mocks/test_generate_query.py
@@ -30,7 +30,8 @@ def test_replace_original_table_references_when_reference_exists():
     """...then the original table reference should be replaced with the mocked table reference"""
     query = f"SELECT * FROM {MockTestTable._sql_mock_meta.table_ref}"
     mock_tables = [MockTestTable()]
-    expected = "SELECT * FROM data__mock_test_table"
+    # Note that sqlglot will add a comment with the original table name at the end
+    expected = "SELECT\n  *\nFROM data__mock_test_table /* data.mock_test_table */"
     assert expected == replace_original_table_references(query, mock_tables)
 
 
@@ -38,7 +39,7 @@ def test_replace_original_table_references_when_reference_does_not_exist():
     """...then the original reference should not be replaced"""
     query = "SELECT * FROM some_table"
     mock_tables = [MockTestTable()]
-    expected = "SELECT * FROM some_table"
+    expected = "SELECT\n  *\nFROM some_table"
     assert expected == replace_original_table_references(query, mock_tables)
 
 
@@ -114,7 +115,7 @@ def test_generate_query_no_cte_provided(mocker):
 
     expected_query_template_result = dedent(
         f"""
-    WITH {mock_table_instance._sql_mock_meta.table_ref} AS (
+    WITH {mock_table_instance.cte_name} AS (
     \tSELECT cast('1' AS Integer) AS col1, cast('hey' AS String) AS col2 FROM (SELECT 1) WHERE FALSE
     ),
 
@@ -135,7 +136,7 @@ def test_generate_query_no_cte_provided(mocker):
     # Asserts
     mocked_select_from_cte.assert_not_called()
     mocked_replace_original_table_references.assert_called_once_with(
-        expected_query_template_result, mock_tables=[mock_table_instance]
+        expected_query_template_result, mock_tables=[mock_table_instance], dialect=mock_table_instance._sql_dialect
     )
     # The final query should be equal to whatever is returned by `replace_original_table_references`
     assert query == mocked_replace_original_table_references.return_value
@@ -159,7 +160,7 @@ def test_generate_query_cte_provided(mocker):
 
     expected_query_template_result = dedent(
         f"""
-    WITH {mock_table_instance._sql_mock_meta.table_ref} AS (
+    WITH {mock_table_instance.cte_name} AS (
     \tSELECT cast('1' AS Integer) AS col1, cast('hey' AS String) AS col2 FROM (SELECT 1) WHERE FALSE
     ),
 
@@ -181,7 +182,7 @@ def test_generate_query_cte_provided(mocker):
         original_query, cte_to_select, sql_dialect=MockTestTable._sql_dialect
     )
     mocked_replace_original_table_references.assert_called_once_with(
-        expected_query_template_result, mock_tables=[mock_table_instance]
+        expected_query_template_result, mock_tables=[mock_table_instance], dialect=mock_table_instance._sql_dialect
     )
     # The final query should be equal to whatever is returned by `replace_original_table_references`
     assert query == mocked_replace_original_table_references.return_value


### PR DESCRIPTION
This unreverts https://github.com/DeepLcom/sql-mock/pull/23 and introduces some additional fixes that we oversaw earlier.

**This still needs the SQLglot issue fixed before merging**