### PR TITLE
Error handling improvements

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1730,13 +1730,13 @@ test = ["pytest"]
 
 [[package]]
 name = "sqlglot"
-version = "20.3.0"
+version = "20.4.0"
 description = "An easily customizable SQL parser and transpiler"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "sqlglot-20.3.0-py3-none-any.whl", hash = "sha256:8d33ee46dbb649dd7499ad1d8f1226cc2a730e3136093440eeba0e5e319f4a1f"},
-    {file = "sqlglot-20.3.0.tar.gz", hash = "sha256:c5a2ea2a1a9958f2918aeac29e8aeb631795e482720bbde98c9ccf5ba78f7554"},
+    {file = "sqlglot-20.4.0-py3-none-any.whl", hash = "sha256:9a42135d0530de8150a2c5106e0c52abd3396d92501ebe97df7b371d20de5dc9"},
+    {file = "sqlglot-20.4.0.tar.gz", hash = "sha256:401a2933298cf66901704cf2029272d8243ee72ac47b9fd8784254401b43ee43"},
 ]
 
 [package.extras]
@@ -1851,4 +1851,4 @@ clickhouse = ["clickhouse-driver"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4ac547ba6cc04a601159e5a2264b0366b03d808dd99ffdc1326a8f53a0e48a20"
+content-hash = "bf6bd91bff672cccf4daa37114c67e67705ffca9869325012d2796bf10198258"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ packages = [
 python = "^3.9"
 jinja2 = "^3.1.2"
 pydantic-settings = "^2.0.3"
-sqlglot = "^20.3.0"
+sqlglot = "^20.4.0"
 
 # Clickhouse specific 
 clickhouse-driver = {extras = ["numpy"], version = "^0.2.6", optional = true}

--- a/src/sql_mock/helpers.py
+++ b/src/sql_mock/helpers.py
@@ -1,0 +1,135 @@
+from collections import Counter
+from typing import TYPE_CHECKING, List
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.expressions import replace_tables
+from sqlglot.optimizer.scope import build_scope
+
+from sql_mock.exceptions import ValidationError
+
+# Needed to avoid circular imports on type check
+if TYPE_CHECKING:
+    from sql_mock.table_mocks import BaseMockTable
+
+
+def get_keys_from_list_of_dicts(data: list[dict]) -> set[str]:
+    return set(key for dictionary in data for key in dictionary.keys())
+
+
+def replace_original_table_references(query: str, mock_tables: list["BaseMockTable"], dialect: str = None):
+    """
+    Replace orignal table references to point them to the mocked data
+
+    Args:
+        query (str): Original SQL query
+        mock_tables (list[BaseMockTable]): List of BaseMockTable instances that are used as input
+        dialect (str): The SQL dialect to use for parsing the query
+    """
+    ast = sqlglot.parse_one(query, dialect=dialect)
+    mapping = {mock_table._sql_mock_meta.table_ref: mock_table.cte_name for mock_table in mock_tables}
+    res = replace_tables(expression=ast, mapping=mapping, dialect=dialect).sql(pretty=True, dialect=dialect)
+    return res
+
+
+def select_from_cte(query: str, cte_name: str, sql_dialect: str):
+    """
+    If selecting from a CTE, we need to replace the the final SELECT statement
+    with a SELECT * FROM select_cte
+
+    Args:
+        query (str): Original SQL query
+        cte_name (str): Name of the CTE to select from
+        sql_dialect (str): The sql dialect to use for generating the query
+    """
+    ast = sqlglot.parse_one(query)
+
+    # Check whether the cte exists, if not raise an error
+    cte_exists = any(cte.alias == cte_name for cte in ast.find_all(sqlglot.exp.CTE))
+    if not cte_exists:
+        raise ValueError(f"CTE with name {cte_name} does not exist in query")
+
+    root_select_statement = ast.find(sqlglot.exp.Select)
+    # Remove all columns from root select statement
+    for col in root_select_statement.find_all((sqlglot.exp.Column, sqlglot.exp.Star)):
+        # Only drop columns from the root select statement
+        if col.parent == root_select_statement:
+            col.pop()
+
+    # Change the final select statement to SELECT * FROM <cte_name>
+    adjusted_query = ast.select("*").from_(cte_name).sql(pretty=True, dialect=sql_dialect)
+    return adjusted_query
+
+
+def _strip_alias_transformer(node):
+    node.set("alias", None)
+    return node
+
+
+def get_source_tables(query, dialect) -> List[str]:
+    """
+    Extract the unique tables that are references in FROM or JOIN statements.
+
+    Based on https://github.com/tobymao/sqlglot/blob/9da41f22bdf5298dc94498173c338cdb16a2d36d/posts/ast_primer.md
+    """
+    ast = sqlglot.parse_one(query, dialect=dialect)
+    root = build_scope(ast)
+
+    tables = {
+        str(source.transform(_strip_alias_transformer))
+        # Traverse the Scope tree, not the AST
+        for scope in root.traverse()
+        # `selected_sources` contains sources that have been selected in this scope, e.g. in a FROM or JOIN clause.
+        # `alias` is the name of this source in this particular scope.
+        # `node` is the AST node instance
+        # if the selected source is a subquery (including common table expressions),
+        #     then `source` will be the Scope instance for that subquery.
+        # if the selected source is a table,
+        #     then `source` will be a Table instance.
+        for alias, (node, source) in scope.selected_sources.items()
+        if isinstance(source, exp.Table)
+    }
+
+    return list(tables)
+
+
+def _validate_unique_input_mocks(input_mocks: List["BaseMockTable"]) -> None:
+    counter = Counter(input_mocks)
+    duplicated_mocks = [mock for mock, cnt in counter.items() if cnt > 1]
+    if duplicated_mocks:
+        msg = f"You provided multiple input mocks for: {duplicated_mocks}"
+        raise ValidationError(msg)
+
+
+def _validate_input_mocks_have_table_ref(input_mocks: List["BaseMockTable"]) -> None:
+    missing_table_refs = [
+        type(mock_table).__name__
+        for mock_table in input_mocks
+        if not getattr(mock_table._sql_mock_meta, "table_ref", False)
+    ]
+
+    if missing_table_refs:
+        missing_table_ref_str = ",".join(missing_table_refs)
+        msg = f"If you want to use a MockTable instance as input, you need to provide a table_reference using the table_meta decorator. Missing table refs for models: {missing_table_ref_str}"
+        raise ValidationError(msg)
+
+
+def validate_input_mocks(input_mocks: List["BaseMockTable"]):
+    _validate_input_mocks_have_table_ref(input_mocks)
+    _validate_unique_input_mocks(input_mocks)
+
+
+def validate_all_input_mocks_for_query_provided(query: str, input_mocks: List["BaseMockTable"], dialect: str) -> None:
+    missing_source_table_mocks = get_source_tables(query=query, dialect=dialect)
+    for mock_table in input_mocks:
+        table_ref = getattr(mock_table._sql_mock_meta, "table_ref", None)
+        # If the table exists as mock, we can remove it from missing source tables
+        try:
+            missing_source_table_mocks.remove(table_ref)
+        except ValueError:
+            msg = f"Your input mock {mock_table.__class__.__name__} is not a table that is referenced in the query"
+            raise ValidationError(msg)
+
+    if missing_source_table_mocks:
+        msg = f"You need to provide the following input mocks to run your query: {missing_source_table_mocks}"
+        raise ValidationError(msg)

--- a/src/sql_mock/table_mocks.py
+++ b/src/sql_mock/table_mocks.py
@@ -299,7 +299,12 @@ class BaseMockTable:
         return f"{self._sql_mock_meta.table_ref} AS (\n{snippet}\n)"
 
     def _assert_equal(
-        self, data: [dict], expected: [dict], ignore_missing_keys: bool = False, ignore_order: bool = True
+        self,
+        data: [dict],
+        expected: [dict],
+        ignore_missing_keys: bool = False,
+        ignore_order: bool = True,
+        print_query_on_fail: bool = True,
     ):
         """
         Assert that the provided data matches the expected data.
@@ -310,6 +315,7 @@ class BaseMockTable:
             ignore_missing_keys (bool): If true, the comparison will only happen for the fields that are present in the
                 list of dictionaries of the `expected` argument.
             ignore_order (bool): If true, the order of dicts / rows will be ignored for comparison.
+            print_query_on_fai (bool)l: If true, the tested query will be printed to the console output when the test fails.
         """
         if ignore_missing_keys:
             keys_to_keep = get_keys_from_list_of_dicts(expected)
@@ -317,10 +323,20 @@ class BaseMockTable:
         if ignore_order:
             data = sorted(data, key=lambda d: sorted(d.items()))
             expected = sorted(expected, key=lambda d: sorted(d.items()))
-        assert expected == data
+        try:
+            assert expected == data
+        except Exception as e:
+            if print_query_on_fail:
+                pass
+            raise e
 
     def assert_cte_equal(
-        self, cte_name, expected: [dict], ignore_missing_keys: bool = False, ignore_order: bool = True
+        self,
+        cte_name,
+        expected: [dict],
+        ignore_missing_keys: bool = False,
+        ignore_order: bool = True,
+        print_query_on_fail: bool = True,
     ):
         """
         Assert that a CTE within the table mock's query equals the provided expected data.
@@ -331,14 +347,25 @@ class BaseMockTable:
             ignore_missing_keys (bool): If true, the comparison will only happen for the fields that are present in the
                 list of dictionaries of the `expected` argument.
             ignore_order (bool): If true, the order of dicts / rows will be ignored for comparison.
+            print_query_on_fail (bool): If true, the tested query will be printed to the console output when the test fails.
         """
         query = self._generate_query(cte_to_select=cte_name)
         data = self._get_results(query)
         self._assert_equal(
-            data=data, expected=expected, ignore_missing_keys=ignore_missing_keys, ignore_order=ignore_order
+            data=data,
+            expected=expected,
+            ignore_missing_keys=ignore_missing_keys,
+            ignore_order=ignore_order,
+            print_query_on_fail=print_query_on_fail,
         )
 
-    def assert_equal(self, expected: [dict], ignore_missing_keys: bool = False, ignore_order: bool = True):
+    def assert_equal(
+        self,
+        expected: [dict],
+        ignore_missing_keys: bool = False,
+        ignore_order: bool = True,
+        print_query_on_fail: bool = True,
+    ):
         """
         Assert that the result of the table mock's query equals the provided expected data.
 
@@ -347,9 +374,14 @@ class BaseMockTable:
             ignore_missing_keys (bool): If true, the comparison will only happen for the fields that are present in the
                 list of dictionaries of the `expected` argument.
             ignore_order (bool): If true, the order of dicts / rows will be ignored for comparison.
+            print_query_on_fail (bool): If true, the tested query will be printed to the console output when the test fails.
         """
         query = self._generate_query()
         data = self._get_results(query)
         self._assert_equal(
-            data=data, expected=expected, ignore_missing_keys=ignore_missing_keys, ignore_order=ignore_order
+            data=data,
+            expected=expected,
+            ignore_missing_keys=ignore_missing_keys,
+            ignore_order=ignore_order,
+            print_query_on_fail=print_query_on_fail,
         )

--- a/src/sql_mock/table_mocks.py
+++ b/src/sql_mock/table_mocks.py
@@ -1,61 +1,18 @@
 from textwrap import dedent, indent
 from typing import List, Type
 
-import sqlglot
 from jinja2 import Template
 from pydantic import BaseModel, ConfigDict, SkipValidation
-from sqlglot.expressions import replace_tables
 
 from sql_mock.column_mocks import ColumnMock
 from sql_mock.constants import NO_INPUT
-from sql_mock.exceptions import ValidationError
-
-
-def get_keys_from_list_of_dicts(data: list[dict]) -> set[str]:
-    return set(key for dictionary in data for key in dictionary.keys())
-
-
-def replace_original_table_references(query: str, mock_tables: list["BaseMockTable"], dialect: str = None):
-    """
-    Replace orignal table references to point them to the mocked data
-
-    Args:
-        query (str): Original SQL query
-        mock_tables (list[BaseMockTable]): List of BaseMockTable instances that are used as input
-    """
-    ast = sqlglot.parse_one(query, dialect=dialect)
-    mapping = {mock_table._sql_mock_meta.table_ref: mock_table.cte_name for mock_table in mock_tables}
-    res = replace_tables(expression=ast, mapping=mapping, dialect=dialect).sql(pretty=True, dialect=dialect)
-    return res
-
-
-def select_from_cte(query: str, cte_name: str, sql_dialect: str):
-    """
-    If selecting from a CTE, we need to replace the the final SELECT statement
-    with a SELECT * FROM select_cte
-
-    Args:
-        query (str): Original SQL query
-        cte_name (str): Name of the CTE to select from
-        sql_dialect (str): The sql dialect to use for generating the query
-    """
-    ast = sqlglot.parse_one(query)
-
-    # Check whether the cte exists, if not raise an error
-    cte_exists = any(cte.alias == cte_name for cte in ast.find_all(sqlglot.exp.CTE))
-    if not cte_exists:
-        raise ValueError(f"CTE with name {cte_name} does not exist in query")
-
-    root_select_statement = ast.find(sqlglot.exp.Select)
-    # Remove all columns from root select statement
-    for col in root_select_statement.find_all((sqlglot.exp.Column, sqlglot.exp.Star)):
-        # Only drop columns from the root select statement
-        if col.parent == root_select_statement:
-            col.pop()
-
-    # Change the final select statement to SELECT * FROM <cte_name>
-    adjusted_query = ast.select("*").from_(cte_name).sql(pretty=True, dialect=sql_dialect)
-    return adjusted_query
+from sql_mock.helpers import (
+    get_keys_from_list_of_dicts,
+    replace_original_table_references,
+    select_from_cte,
+    validate_all_input_mocks_for_query_provided,
+    validate_input_mocks,
+)
 
 
 class MockTableMeta(BaseModel):
@@ -104,19 +61,6 @@ def table_meta(
         return cls
 
     return decorator
-
-
-def validate_input_mocks(table_mocks: list["BaseMockTable"]):
-    # Check that each input table mock has a _table_ref defined
-    missing_table_refs = [
-        type(mock_table).__name__
-        for mock_table in table_mocks
-        if not getattr(mock_table._sql_mock_meta, "table_ref", False)
-    ]
-    if missing_table_refs:
-        missing_table_ref_str = ",".join(missing_table_refs)
-        msg = f"If you want to use a MockTable instance as input, you need to provide a table_reference using the table_meta decorator. Missing table refs for models: {missing_table_ref_str}"
-        raise ValidationError(msg)
 
 
 class SQLMockData(BaseModel):
@@ -198,7 +142,10 @@ class BaseMockTable:
             query_template_kwargs: Dictionary of Jinja template key-value pairs that should be used to render the query.
             query: String of the SQL query that is used to generate the model. Can be a Jinja template. If provided, it overwrites the query on cls._sql_mock_meta.query.
         """
-        validate_input_mocks(input_data)
+        instance = cls(data=[])
+        query_template = Template(query or cls._sql_mock_meta.query)
+        query = query_template.render(query_template_kwargs or {})
+        instance._sql_mock_data.rendered_query = query
 
         # Update defaults with provided data. We use the table ref dictionaries to avoid duplicated inputs.
         if getattr(cls._sql_mock_data, "default_inputs", None):
@@ -208,12 +155,9 @@ class BaseMockTable:
             input_dict = {mock_table._sql_mock_meta.table_ref: mock_table for mock_table in input_data}
             input_data = list({**default_inputs, **input_dict}.values())
 
-        instance = cls(data=[])
-        query_template = Template(query or cls._sql_mock_meta.query)
-
-        # Assign instance attributes
+        validate_input_mocks(input_data)
+        validate_all_input_mocks_for_query_provided(query=query, dialect=cls._sql_dialect, input_mocks=input_data)
         instance._sql_mock_data.input_data = input_data
-        instance._sql_mock_data.rendered_query = query_template.render(query_template_kwargs or {})
 
         return instance
 

--- a/tests/sql_mock/bigquery/test_table_mocks.py
+++ b/tests/sql_mock/bigquery/test_table_mocks.py
@@ -50,6 +50,7 @@ def test_get_results(mocker):
         {"column1": "value3", "column2": "value4"}
         # Add more rows as needed
     ]
+    query = "SELECT 1, 2"
 
     # Mock the Client and QueryJob classes and their methods
     mocker.patch("google.cloud.bigquery.Client")
@@ -57,7 +58,8 @@ def test_get_results(mocker):
     query_job_instance = mock_client.query.return_value
     query_job_instance.result.return_value = mock_query_job_result
 
-    result = BigQueryMockTable.from_mocks(query="SELECT 1", input_data=[MockTestTable(data=[])])
+    instance = BigQueryMockTable()
+    result = instance._get_results(query=query)
 
-    # Assert the result matches the expected mock result
-    result.assert_equal(mock_query_job_result)
+    assert result == mock_query_job_result
+    mock_client.query.assert_called_once_with(query)

--- a/tests/sql_mock/clickhouse/test_table_mocks.py
+++ b/tests/sql_mock/clickhouse/test_table_mocks.py
@@ -57,11 +57,14 @@ def test_get_results(mocker):
     """
     mock_client = mocker.patch("sql_mock.clickhouse.table_mocks.Client")
     mock_query_result = [{"column1": "value1", "column2": 42}]
+    query = "SELECT 1, 2"
+
     mock_dataframe = mocker.MagicMock()
     mock_dataframe.to_dict.return_value = mock_query_result
     mock_client.return_value.__enter__.return_value.query_dataframe.return_value = mock_dataframe
 
-    table = ClickHouseTableMock()
-    result = table.from_mocks(query="SELECT foo FROM bar", input_data=[MockTestTable()])
+    instance = ClickHouseTableMock()
+    result = instance._get_results(query=query)
 
-    result.assert_equal(mock_query_result)
+    assert result == mock_query_result
+    mock_client.return_value.__enter__.return_value.query_dataframe.assert_called_once_with(query)

--- a/tests/sql_mock/test_helpers.py
+++ b/tests/sql_mock/test_helpers.py
@@ -1,0 +1,226 @@
+# Test validate input mocks function
+import pytest
+import sqlglot
+
+from sql_mock.column_mocks import ColumnMock
+from sql_mock.exceptions import ValidationError
+from sql_mock.helpers import (
+    _validate_input_mocks_have_table_ref,
+    _validate_unique_input_mocks,
+    get_source_tables,
+    replace_original_table_references,
+    select_from_cte,
+    validate_all_input_mocks_for_query_provided,
+    validate_input_mocks,
+)
+from sql_mock.table_mocks import BaseMockTable, table_meta
+
+
+class NoTableRefMock(BaseMockTable):
+    pass
+
+
+@table_meta(table_ref="some_table")
+class TableRefMock(BaseMockTable):
+    def _get_results(self):
+        return []
+
+
+class IntTestColumn(ColumnMock):
+    dtype = "Integer"
+
+
+class StringTestColumn(ColumnMock):
+    dtype = "String"
+
+
+int_col = IntTestColumn(default=1)
+string_col = StringTestColumn(default="hey")
+
+
+@table_meta(table_ref="data.mock_test_table")
+class MockTestTable(BaseMockTable):
+    col1 = int_col
+    col2 = string_col
+    _sql_dialect = "bigquery"
+
+
+class TestReplaceOriginalTableReference:
+    def test_replace_original_table_references_when_reference_exists(self):
+        """...then the original table reference should be replaced with the mocked table reference"""
+        query = f"SELECT * FROM {MockTestTable._sql_mock_meta.table_ref}"
+        mock_tables = [MockTestTable()]
+        # Note that sqlglot will add a comment with the original table name at the end
+        expected = "SELECT\n  *\nFROM data__mock_test_table /* data.mock_test_table */"
+        assert expected == replace_original_table_references(query, mock_tables)
+
+    def test_replace_original_table_references_when_reference_does_not_exist(self):
+        """...then the original reference should not be replaced"""
+        query = "SELECT * FROM some_table"
+        mock_tables = [MockTestTable()]
+        expected = "SELECT\n  *\nFROM some_table"
+        assert expected == replace_original_table_references(query, mock_tables)
+
+
+class TestSelectFromCTE:
+    def test_select_from_cte_when_cte_exists(self):
+        """...then the final select of the query should be replaced with a select from the cte"""
+        cte_name = "cte_1"
+        query = """
+        WITH cte_1 AS (
+        SELECT * FROM some_table
+        ),
+        cte_2 AS (
+        SELECT a, b
+        FROM cte
+        WHERE a = 'foo'
+        )
+
+        SELECT a, b, * FROM cte_2
+        """
+
+        expected = sqlglot.parse_one(
+            """
+        WITH cte_1 AS (
+        SELECT * FROM some_table
+        ),
+        cte_2 AS (
+        SELECT a, b
+        FROM cte
+        WHERE a = 'foo'
+        )
+
+        SELECT * FROM cte_1
+        """
+        )
+        # Make sure we match the query format
+        expected = expected.sql(pretty=True)
+
+        assert expected == select_from_cte(query, cte_name, sql_dialect="bigquery")
+
+    def test_select_from_cte_when_cte_does_not_exist(self):
+        """...then the method should raise a ValueError"""
+        cte_name = "cte_1"
+        query = """
+        WITH cte_2 AS (
+        SELECT a, b
+        FROM cte
+        WHERE a = 'foo'
+        )
+
+        SELECT * FROM cte_2
+        """
+
+        with pytest.raises(ValueError):
+            select_from_cte(query, cte_name, sql_dialect="bigquery")
+
+
+class TestValidateUniqueInputMocks:
+    def test_input_mocks_not_unique(self):
+        """...then it should raise an error"""
+        with pytest.raises(ValidationError):
+            _validate_unique_input_mocks(input_mocks=[TableRefMock, TableRefMock])
+
+    def test_input_mocks_unique(self):
+        """...then it should NOT raise an error"""
+        _validate_unique_input_mocks(input_mocks=[TableRefMock, NoTableRefMock])
+
+
+class TestValidateInputMocksHaveTableRef:
+    def test_validate_input_mocks_no_table_ref_provided(self):
+        """...then a validation error should be raised"""
+        with pytest.raises(ValidationError):
+            _validate_input_mocks_have_table_ref(input_mocks=[NoTableRefMock()])
+
+    def test_validate_input_mocks_with_table_ref_provided(self):
+        """...then a validation error should be raised"""
+        # Should not raise an error
+        _validate_input_mocks_have_table_ref(input_mocks=[TableRefMock()])
+
+
+def test_validate_input_mocks(mocker):
+    mocked_unique_input_mocks_validation = mocker.patch("sql_mock.helpers._validate_unique_input_mocks")
+    mocked_table_ref_validation = mocker.patch("sql_mock.helpers._validate_input_mocks_have_table_ref")
+    input_mocks = [TableRefMock, NoTableRefMock]
+
+    validate_input_mocks(input_mocks=input_mocks)
+
+    mocked_unique_input_mocks_validation.assert_called_once_with(input_mocks)
+    mocked_table_ref_validation.assert_called_once_with(input_mocks)
+
+
+class TestValidateAllInputMocksForQueryProvided:
+    query = """
+    SELECT
+        *
+    FROM foo.foo AS f
+    LEFT JOIN bar.bar AS b ON f.bar_id = b.id
+    """
+
+    @table_meta(table_ref="bar.bar")
+    class BarMock(BaseMockTable):
+        pass
+
+    @table_meta(table_ref="foo.foo")
+    class FooMock(BaseMockTable):
+        pass
+
+    def test_all_input_mocks_provided(self):
+        """...then the validation should pass"""
+        validate_all_input_mocks_for_query_provided(
+            query=self.query, input_mocks=[self.BarMock, self.FooMock], dialect="bigquery"
+        )
+
+    def test_input_mocks_missing(self):
+        """...then the validation should fail"""
+        with pytest.raises(ValidationError) as e:
+            validate_all_input_mocks_for_query_provided(
+                query=self.query, input_mocks=[self.BarMock], dialect="bigquery"
+            )
+        assert str(e.value) == f"You need to provide the following input mocks to run your query: {['foo.foo']}"
+
+    def test_input_mocks_not_in_query(self):
+        """...then the validation should fail"""
+        with pytest.raises(ValidationError) as e:
+            validate_all_input_mocks_for_query_provided(
+                query=self.query, input_mocks=[self.BarMock, self.FooMock, TableRefMock], dialect="bigquery"
+            )
+        assert (
+            str(e.value)
+            == f"Your input mock {TableRefMock.__class__.__name__} is not a table that is referenced in the query"
+        )
+
+
+class TestGetSourceTables:
+    def test_query_with_ctes(self):
+        """...then only the real source table should be extracted"""
+        query = """
+        WITH foo AS (
+            SELECT 1 FROM table_1
+        )
+
+        SELECT 2 FROM table_2
+        """
+
+        res = get_source_tables(query, dialect="bigquery")
+
+        expected = ["table_1", "table_2"]
+        assert len(res) == len(expected)
+        assert all([val in expected for val in res])
+
+    def test_query_with_multiple_references_of_single_table(self):
+        """...then the tables should be unique"""
+
+        query = """
+        SELECT
+            t1.1,
+            t2.2
+        FROM table_2 AS t1
+        CROSS JOIN table_2 AS t2
+        """
+
+        res = get_source_tables(query, dialect="bigquery")
+
+        expected = ["table_2"]
+        assert len(res) == len(expected)
+        assert all([val in expected for val in res])

--- a/tests/sql_mock/test_table_mocks.py
+++ b/tests/sql_mock/test_table_mocks.py
@@ -1,7 +1,6 @@
 import pytest
 
 from sql_mock.column_mocks import ColumnMock
-from sql_mock.exceptions import ValidationError
 from sql_mock.table_mocks import BaseMockTable, table_meta
 
 
@@ -52,35 +51,46 @@ def test_wrong_fields_prodivded_to_model():
         MockTestTable(data=[{"not_existing_key": 1}])
 
 
-# Test the from_mocks method
-def test_from_mocks(base_mock_table_instance):
-    query = "SELECT * FROM some_table"
-    input_data = [base_mock_table_instance]
-    query_template_kwargs = {}
+class TestFromMocks:
+    def test_from_mocks(self, base_mock_table_instance, mocker):
+        query = "SELECT * FROM some_table"
+        input_data = [base_mock_table_instance]
+        query_template_kwargs = {}
+        mocked_validate_input_mocks_for_query = mocker.patch(
+            "sql_mock.table_mocks.validate_all_input_mocks_for_query_provided"
+        )
+        mocked_validate_input_mocks = mocker.patch("sql_mock.table_mocks.validate_input_mocks")
 
-    instance = MockTestTable.from_mocks(
-        query=query, input_data=input_data, query_template_kwargs=query_template_kwargs
-    )
+        instance = MockTestTable.from_mocks(
+            query=query, input_data=input_data, query_template_kwargs=query_template_kwargs
+        )
 
-    assert isinstance(instance, MockTestTable)
-    assert instance._sql_mock_data.input_data == input_data
-    assert instance._sql_mock_data.rendered_query == query
-    assert instance._sql_mock_data.data == []
+        assert isinstance(instance, MockTestTable)
+        assert instance._sql_mock_data.input_data == input_data
+        assert instance._sql_mock_data.rendered_query == query
+        assert instance._sql_mock_data.data == []
+        mocked_validate_input_mocks_for_query.assert_called_once()
+        mocked_validate_input_mocks.assert_called_once()
 
+    def test_from_mocks_with_defaults(self, base_mock_table_instance, mocker):
+        query = "SELECT * FROM some_table"
+        input_data = [*MockTestTableWithDefaults._sql_mock_data.default_inputs, base_mock_table_instance]
+        query_template_kwargs = {}
+        mocked_validate_input_mocks_for_query = mocker.patch(
+            "sql_mock.table_mocks.validate_all_input_mocks_for_query_provided"
+        )
+        mocked_validate_input_mocks = mocker.patch("sql_mock.table_mocks.validate_input_mocks")
 
-def test_from_mocks_with_defaults(base_mock_table_instance):
-    query = "SELECT * FROM some_table"
-    input_data = [*MockTestTableWithDefaults._sql_mock_data.default_inputs, base_mock_table_instance]
-    query_template_kwargs = {}
+        instance = MockTestTableWithDefaults.from_mocks(
+            query=query, input_data=input_data, query_template_kwargs=query_template_kwargs
+        )
 
-    instance = MockTestTableWithDefaults.from_mocks(
-        query=query, input_data=input_data, query_template_kwargs=query_template_kwargs
-    )
-
-    assert isinstance(instance, MockTestTableWithDefaults)
-    assert instance._sql_mock_data.input_data == input_data
-    assert instance._sql_mock_data.rendered_query == query
-    assert instance._sql_mock_data.data == []
+        assert isinstance(instance, MockTestTableWithDefaults)
+        assert instance._sql_mock_data.input_data == input_data
+        assert instance._sql_mock_data.rendered_query == query
+        assert instance._sql_mock_data.data == []
+        mocked_validate_input_mocks_for_query.assert_called_once()
+        mocked_validate_input_mocks.assert_called_once()
 
 
 # Test the _generate_input_data_cte_snippet method
@@ -109,94 +119,64 @@ def test_as_sql_input():
     assert expected == sql_input
 
 
-# Test the _to_sql_row method
-def test_to_sql_row_all_values_provided():
-    """...then the values should be used"""
-    mock_data = [{"col1": 42, "col2": "test_value"}]
-    mock_table = MockTestTable(data=mock_data)
-    sql_row = mock_table._to_sql_row(mock_data[0])
+class TestToSqlRow:
+    def test_to_sql_row_all_values_provided(self):
+        """...then the values should be used"""
+        mock_data = [{"col1": 42, "col2": "test_value"}]
+        mock_table = MockTestTable(data=mock_data)
+        sql_row = mock_table._to_sql_row(mock_data[0])
 
-    expected_sql_row = "cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2"
-    assert sql_row == expected_sql_row
+        expected_sql_row = "cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2"
+        assert sql_row == expected_sql_row
 
+    def test_to_sql_row_only_some_values_provided(self):
+        """...then the missing values should be filled with the default"""
+        mock_data = [{"col1": 42}]
+        mock_table = MockTestTable(data=mock_data)
+        sql_row = mock_table._to_sql_row(mock_data[0])
 
-def test_to_sql_row_only_some_values_provided():
-    """...then the missing values should be filled with the default"""
-    mock_data = [{"col1": 42}]
-    mock_table = MockTestTable(data=mock_data)
-    sql_row = mock_table._to_sql_row(mock_data[0])
-
-    expected_sql_row = "cast('42' AS Integer) AS col1, cast('hey' AS String) AS col2"
-    assert sql_row == expected_sql_row
-
-
-# Test the _to_sql_model method
-def test_to_sql_model_no_data_provided():
-    """...then it should populate a dummy row with defaults but filter for no results with WHERE FALSE"""
-    mock_data = []
-    mock_table = MockTestTable(mock_data)
-    sql_model = mock_table.as_sql_input()
-
-    expected_sql_model = (
-        "mock_test_table AS (\n"
-        "\tSELECT cast('1' AS Integer) AS col1, cast('hey' AS String) AS col2 FROM (SELECT 1) WHERE FALSE\n"
-        ")"
-    )
-    assert sql_model == expected_sql_model
+        expected_sql_row = "cast('42' AS Integer) AS col1, cast('hey' AS String) AS col2"
+        assert sql_row == expected_sql_row
 
 
-def test_to_sql_model_single_row_provided():
-    """...then it should only select data for that row and not add UNION ALL"""
-    mock_data = [{"col1": 42, "col2": "test_value"}]
-    mock_table = MockTestTable(mock_data)
-    sql_model = mock_table.as_sql_input()
+class TestToSqlModel:
+    def test_to_sql_model_no_data_provided(self):
+        """...then it should populate a dummy row with defaults but filter for no results with WHERE FALSE"""
+        mock_data = []
+        mock_table = MockTestTable(mock_data)
+        sql_model = mock_table.as_sql_input()
 
-    expected_sql_model = (
-        "mock_test_table AS (\n" "\tSELECT cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2\n" ")"
-    )
-    assert sql_model == expected_sql_model
+        expected_sql_model = (
+            "mock_test_table AS (\n"
+            "\tSELECT cast('1' AS Integer) AS col1, cast('hey' AS String) AS col2 FROM (SELECT 1) WHERE FALSE\n"
+            ")"
+        )
+        assert sql_model == expected_sql_model
 
+    def test_to_sql_model_single_row_provided(self):
+        """...then it should only select data for that row and not add UNION ALL"""
+        mock_data = [{"col1": 42, "col2": "test_value"}]
+        mock_table = MockTestTable(mock_data)
+        sql_model = mock_table.as_sql_input()
 
-def test_to_sql_model_multiple_provided():
-    """...then it should combine the rows with UNION ALL"""
-    mock_data = [{"col1": 42, "col2": "test_value"}, {"col1": 100, "col2": "another_value"}]
-    mock_table = MockTestTable(mock_data)
-    sql_model = mock_table.as_sql_input()
+        expected_sql_model = (
+            "mock_test_table AS (\n"
+            "\tSELECT cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2\n"
+            ")"
+        )
+        assert sql_model == expected_sql_model
 
-    expected_sql_model = (
-        "mock_test_table AS (\n"
-        "\tSELECT cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2\n"
-        "\tUNION ALL\n"
-        "\tSELECT cast('100' AS Integer) AS col1, cast('another_value' AS String) AS col2\n"
-        ")"
-    )
-    assert sql_model == expected_sql_model
+    def test_to_sql_model_multiple_provided(self):
+        """...then it should combine the rows with UNION ALL"""
+        mock_data = [{"col1": 42, "col2": "test_value"}, {"col1": 100, "col2": "another_value"}]
+        mock_table = MockTestTable(mock_data)
+        sql_model = mock_table.as_sql_input()
 
-
-# Test validate input mocks function
-def test_validate_input_mocks_no_table_ref_provided(mocker):
-    """...then a validation error should be raised"""
-
-    class NoTableRefMock(BaseMockTable):
-        pass
-
-    # Patch _get_results that we don't need to implement it
-    mocker.patch.object(BaseMockTable, "_get_results", return_value=[])
-
-    with pytest.raises(ValidationError):
-        BaseMockTable.from_mocks(query="SELECT 1", input_data=[NoTableRefMock()])
-
-
-def test_validate_input_mocks_with_table_ref_provided(mocker):
-    """...then a validation error should be raised"""
-
-    @table_meta(table_ref="some_table")
-    class TableRefMock(BaseMockTable):
-        def _get_results(self):
-            return []
-
-    # Patch _get_results that we don't need to implement it
-    mocker.patch.object(BaseMockTable, "_get_results", return_value=[])
-
-    # Should not raise an error
-    BaseMockTable.from_mocks(query="SELECT 1", input_data=[TableRefMock()])
+        expected_sql_model = (
+            "mock_test_table AS (\n"
+            "\tSELECT cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2\n"
+            "\tUNION ALL\n"
+            "\tSELECT cast('100' AS Integer) AS col1, cast('another_value' AS String) AS col2\n"
+            ")"
+        )
+        assert sql_model == expected_sql_model

--- a/tests/test_table_mocks/test_assert_equal.py
+++ b/tests/test_table_mocks/test_assert_equal.py
@@ -135,7 +135,11 @@ def test_assert_equal(mocker, ignore_missing_keys, ignore_order):
     instance.assert_equal(expected=data, ignore_missing_keys=ignore_missing_keys, ignore_order=ignore_order)
 
     mocked_assert_equal.assert_called_once_with(
-        data=data, expected=data, ignore_missing_keys=ignore_missing_keys, ignore_order=ignore_order
+        data=data,
+        expected=data,
+        ignore_missing_keys=ignore_missing_keys,
+        ignore_order=ignore_order,
+        print_query_on_fail=True,
     )
 
 
@@ -156,6 +160,10 @@ def test_assert_cte_equal(mocker, ignore_missing_keys, ignore_order):
     )
 
     mocked_assert_equal.assert_called_once_with(
-        data=data, expected=data, ignore_missing_keys=ignore_missing_keys, ignore_order=ignore_order
+        data=data,
+        expected=data,
+        ignore_missing_keys=ignore_missing_keys,
+        ignore_order=ignore_order,
+        print_query_on_fail=True,
     )
     mocked_generate_query.assert_called_once_with(cte_to_select=cte_name)


### PR DESCRIPTION
# Problem

Often when creating first SQLMock tests, the tests tend to fail because of wrong setup reasons.
We forget to mock a specific table reference or we gave some wrong input values.
Currently, it is hard to debug for new users and we should improve this

# What changed
This commit adds improved error handling that also make debugging easier:

1. We validate provided input mocks for completeness (i.e. are all table references mocked)
2. We validate provided input mocks to be correct (i.e. actually present in the query and not duplicated)
3. We print the last query if a test failed. This can also help debugging what went wrong