### PR TITLE
Column Mock improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* BigQuery column types
 
 ### Changed
+* ColumnMock nullable by default
 
 ### Breaking Changes
 * Path to dbt project.yml file is provided instead of manifest.json
+* Array types use other ColumnMock classes as inner type
 
 ### Fixed
 * Fixed generation of CTE names from references with hyphens

--- a/src/sql_mock/bigquery/column_mocks.py
+++ b/src/sql_mock/bigquery/column_mocks.py
@@ -1,8 +1,13 @@
+from typing import Any
 from sql_mock.column_mocks import BaseColumnMock
 
 
 class BigQueryColumnMock(BaseColumnMock):
     pass
+
+
+class Boolean(BigQueryColumnMock):
+    dtype = 'Boolean'
 
 
 class Int(BigQueryColumnMock):
@@ -27,14 +32,18 @@ class Decimal(BigQueryColumnMock):
         super().__init__(default, nullable)
 
 
+class Timestamp(BigQueryColumnMock):
+    dtype = 'Timestamp'
+
+
 class Array(BigQueryColumnMock):
     use_quotes_for_casting = False
 
     def __init__(
         self,
-        inner_dtype,
-        default,
-        nullable=False,
+        inner_type: BigQueryColumnMock,
+        default: Any,
+        nullable: bool=False,
     ) -> None:
-        self.dtype = f"Array<{inner_dtype}>"
+        self.dtype = f"Array<{inner_type.dtype}>"
         super().__init__(default, nullable)

--- a/src/sql_mock/clickhouse/column_mocks.py
+++ b/src/sql_mock/clickhouse/column_mocks.py
@@ -1,3 +1,4 @@
+from typing import Any
 from sql_mock.column_mocks import BaseColumnMock
 
 
@@ -47,9 +48,9 @@ class Array(ClickhouseColumnMock):
 
     def __init__(
         self,
-        inner_dtype,
-        default,
-        nullable=False,
+        inner_type: ClickhouseColumnMock,
+        default: Any,
+        nullable: bool=False,
     ) -> None:
-        self.dtype = f"Array({inner_dtype})"
+        self.dtype = f"Array({inner_type.dtype})"
         super().__init__(default, nullable)

--- a/src/sql_mock/column_mocks.py
+++ b/src/sql_mock/column_mocks.py
@@ -14,11 +14,11 @@ class BaseColumnMock:
     """
 
     dtype = None
-    nullable = False
+    nullable = True
     default = None
     use_quotes_for_casting = True
 
-    def __init__(self, default=None, nullable=False) -> None:
+    def __init__(self, default=None, nullable=True) -> None:
         """
         Initialize a BaseColumnMock instance.
 

--- a/tests/sql_mock/bigquery/test_column_mocks.py
+++ b/tests/sql_mock/bigquery/test_column_mocks.py
@@ -1,9 +1,9 @@
-from sql_mock.bigquery.column_mocks import Array, BigQueryColumnMock, Decimal
+from sql_mock.bigquery.column_mocks import Array, BigQueryColumnMock, Decimal, String, Int
 
 
-def test_init_not_nullable():
+def test_init_nullable():
     """
-    ...then nullable should be False and dtype be the same as passed.
+    ...then nullable should be tRUE and dtype be the same as passed.
     """
 
     class ColMock(BigQueryColumnMock):
@@ -13,22 +13,22 @@ def test_init_not_nullable():
 
     assert column.default == 42
     assert column.dtype == "Integer"
-    assert not column.nullable
+    assert column.nullable
 
 
 def test_init_nullable():
     """
-    ...then nullable should be True"
+    ...then nullable should be False"
     """
 
     class ColMock(BigQueryColumnMock):
         dtype = "Integer"
 
-    column = ColMock(default=42, nullable=True)
+    column = ColMock(default=42, nullable=False)
 
     assert column.default == 42
     assert column.dtype == "Integer"
-    assert column.nullable
+    assert not column.nullable
 
 
 class TestDecimalColumn:
@@ -49,8 +49,8 @@ class TestDecimalColumn:
 
 def test_array_column_inner_dtype():
     """Ensure that the inner dtype is processed correctly"""
-    string_array_col = Array(inner_dtype="String", default=["a", "b"], nullable=True)
-    int_array_col = Array(inner_dtype="Integer", default=[1, 2], nullable=False)
+    string_array_col = Array(inner_type=String, default=["a", "b"], nullable=True)
+    int_array_col = Array(inner_type=Int, default=[1, 2], nullable=False)
 
     assert string_array_col.dtype == "Array<String>"
     assert string_array_col.default == ["a", "b"]

--- a/tests/sql_mock/clickhouse/test_column_mocks.py
+++ b/tests/sql_mock/clickhouse/test_column_mocks.py
@@ -1,9 +1,9 @@
-from sql_mock.clickhouse.column_mocks import Array, ClickhouseColumnMock, Decimal
+from sql_mock.clickhouse.column_mocks import Array, ClickhouseColumnMock, Decimal, String, Int
 
 
 def test_init_not_nullable():
     """
-    ...then nullable should be False and dtype be the same as passed.
+    ...then nullable should be True and dtype be the same as passed.
     """
 
     class ColMock(ClickhouseColumnMock):
@@ -18,7 +18,7 @@ def test_init_not_nullable():
 
 def test_init_nullable():
     """
-    ...then nullable should be True and dtype should be wrapped with "Nullable()"
+    ...then nullable should be False and dtype should be wrapped with "Nullable()"
     """
 
     class ColMock(ClickhouseColumnMock):
@@ -49,8 +49,8 @@ def test_decimal_initialization_nullable():
 
 def test_array_column_inner_dtype():
     """Ensure that the inner dtype is processed correctly"""
-    string_array_col = Array(inner_dtype="String", default=["a", "b"], nullable=True)
-    int_array_col = Array(inner_dtype="Integer", default=[1, 2], nullable=False)
+    string_array_col = Array(inner_type=String, default=["a", "b"], nullable=True)
+    int_array_col = Array(inner_type=Int, default=[1, 2], nullable=False)
 
     assert string_array_col.dtype == "Nullable(Array(String))"
     assert string_array_col.default == ["a", "b"]

--- a/tests/sql_mock/redshift/test_column_mocks.py
+++ b/tests/sql_mock/redshift/test_column_mocks.py
@@ -1,9 +1,9 @@
 from sql_mock.redshift.column_mocks import RedshiftColumnMock, DECIMAL
 
 
-def test_init_not_nullable():
+def test_init_nullable():
     """
-    ...then nullable should be False and dtype be the same as passed.
+    ...then nullable should be True and dtype be the same as passed.
     """
 
     class ColMock(RedshiftColumnMock):
@@ -13,22 +13,22 @@ def test_init_not_nullable():
 
     assert column.default == 42
     assert column.dtype == "BIGINT"
-    assert not column.nullable
+    assert column.nullable
 
 
-def test_init_nullable():
+def test_init_not_nullable():
     """
-    ...then nullable should be True"
+    ...then nullable should be False"
     """
 
     class ColMock(RedshiftColumnMock):
         dtype = "BIGINT"
 
-    column = ColMock(default=42, nullable=True)
+    column = ColMock(default=42, nullable=False)
 
     assert column.default == 42
     assert column.dtype == "BIGINT"
-    assert column.nullable
+    assert not column.nullable
 
 
 class TestDecimalColumn:

--- a/tests/sql_mock/snowflake/test_column_mocks.py
+++ b/tests/sql_mock/snowflake/test_column_mocks.py
@@ -1,9 +1,9 @@
 from sql_mock.snowflake.column_mocks import DECIMAL, SnowflakeColumnMock
 
 
-def test_init_not_nullable():
+def test_init_nullable():
     """
-    ...then nullable should be False and dtype be the same as passed.
+    ...then nullable should be True and dtype be the same as passed.
     """
 
     class ColMock(SnowflakeColumnMock):
@@ -13,22 +13,22 @@ def test_init_not_nullable():
 
     assert column.default == 42
     assert column.dtype == "INTEGER"
-    assert not column.nullable
+    assert column.nullable
 
 
-def test_init_nullable():
+def test_init_not_nullable():
     """
-    ...then nullable should be True"
+    ...then nullable should be False"
     """
 
     class ColMock(SnowflakeColumnMock):
         dtype = "INTEGER"
 
-    column = ColMock(default=42, nullable=True)
+    column = ColMock(default=42, nullable=False)
 
     assert column.default == 42
     assert column.dtype == "INTEGER"
-    assert column.nullable
+    assert not column.nullable
 
 
 class TestDecimalColumn:

--- a/tests/sql_mock/test_column_mocks.py
+++ b/tests/sql_mock/test_column_mocks.py
@@ -11,22 +11,22 @@ def test_init_no_default_not_nullable():
         BaseColumnMock(default=None, nullable=False)
 
 
-def test_init_default_not_nullable():
-    """
-    ...then it should set the default value and nullable should be False.
-    """
-    column = BaseColumnMock(default=42)
-    assert column.default == 42
-    assert not column.nullable
-
-
 def test_init_default_nullable():
     """
     ...then it should set the default value and nullable should be True.
     """
-    column = BaseColumnMock(default="Hello", nullable=True)
-    assert column.default == "Hello"
+    column = BaseColumnMock(default=42)
+    assert column.default == 42
     assert column.nullable
+
+
+def test_init_default_not_nullable():
+    """
+    ...then it should set the default value and nullable should be False.
+    """
+    column = BaseColumnMock(default="Hello", nullable=False)
+    assert column.default == "Hello"
+    assert not column.nullable
 
 
 def test_to_sql_with_value():


### PR DESCRIPTION
## What problem does this PR solve
The PR contains multiple small improvements to the usability of Column Mocks

## What changed
* made column mock nullable by default
* array inner types use other column mocks
* added BigQuery column mocks

## Checklist

- [x] I added tests for new functionality if applicable
- [x] I added an entry for changes to the unreleased changes of CHANGELOG.md
- [x] I added documentation for new functionality if applicable
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
