### PR TITLE
Allow cte mocks

### DIFF
--- a/tests/sql_mock/test_helpers.py
+++ b/tests/sql_mock/test_helpers.py
@@ -48,18 +48,26 @@ class MockTestTable(BaseTableMock):
 class TestReplaceOriginalTableReference:
     def test_replace_original_table_references_when_reference_exists(self):
         """...then the original table reference should be replaced with the mocked table reference"""
-        query = f"SELECT * FROM {MockTestTable._sql_mock_meta.table_ref}"
-        mock_tables = [MockTestTable()]
+        query_ast = sqlglot.parse_one(f"SELECT * FROM {MockTestTable._sql_mock_meta.table_ref}")
         # Note that sqlglot will add a comment with the original table name at the end
-        expected = "SELECT\n  *\nFROM data__mock_test_table /* data.mock_test_table */"
-        assert expected == replace_original_table_references(query, mock_tables)
+        expected = f"SELECT\n  *\nFROM {MockTestTable._sql_mock_meta.cte_name} /* data.mock_test_table */"
+        assert expected == replace_original_table_references(
+            query_ast=query_ast,
+            table_ref=MockTestTable._sql_mock_meta.table_ref,
+            sql_mock_cte_name=MockTestTable._sql_mock_meta.cte_name,
+            dialect="bigquery",
+        ).sql(pretty=True)
 
     def test_replace_original_table_references_when_reference_does_not_exist(self):
         """...then the original reference should not be replaced"""
-        query = "SELECT * FROM some_table"
-        mock_tables = [MockTestTable()]
+        query_ast = sqlglot.parse_one("SELECT * FROM some_table")
         expected = "SELECT\n  *\nFROM some_table"
-        assert expected == replace_original_table_references(query, mock_tables)
+        assert expected == replace_original_table_references(
+            query_ast=query_ast,
+            table_ref=MockTestTable._sql_mock_meta.table_ref,
+            sql_mock_cte_name=MockTestTable._sql_mock_meta.cte_name,
+            dialect="bigquery",
+        ).sql(pretty=True)
 
 
 class TestSelectFromCTE:
@@ -190,6 +198,52 @@ class TestValidateAllInputMocksForQueryProvided:
             == f"Your input mock {TableRefMock.__class__.__name__} is not a table that is referenced in the query"
         )
 
+    def test_input_mocks_missing_for_tables_within_mocked_cte(self):
+        """...then the validation should pass since the CTE would be mocked anyways"""
+        query = """
+        WITH cte_1 AS (
+            SELECT * FROM some_table
+        ),
+
+        cte_2 AS (
+            SELECT a, b
+            FROM cte_1
+            WHERE a = 'foo'
+        )
+
+        SELECT a, b, * FROM cte_2
+        """
+        @table_meta(table_ref="cte_1")
+        class Cte1Mock(BaseTableMock):
+            pass
+
+        validate_all_input_mocks_for_query_provided(
+            query=query, input_mocks=[Cte1Mock()], dialect="bigquery"
+        )
+
+    def test_cte_superfluous_after_mocking(self):
+        """...then the validation should pass since the CTE will be removed anyways and does not need to be mocked"""
+        query = """
+        WITH cte_1 AS (
+            SELECT * FROM some_table
+        ),
+
+        cte_2 AS (
+            SELECT a, b
+            FROM cte_1
+            WHERE a = 'foo'
+        )
+
+        SELECT a, b, * FROM cte_2
+        """
+        @table_meta(table_ref="cte_2") # This will make cte_1 superfluous
+        class Cte1Mock(BaseTableMock):
+            pass
+
+        validate_all_input_mocks_for_query_provided(
+            query=query, input_mocks=[Cte1Mock()], dialect="bigquery"
+        )
+
 
 class TestGetSourceTables:
     def test_query_with_ctes(self):
@@ -224,3 +278,18 @@ class TestGetSourceTables:
         expected = ["table_2"]
         assert len(res) == len(expected)
         assert all([val in expected for val in res])
+
+    def test_query_with_comment(self):
+        """...then the comment should be ignored"""
+
+        query = """
+        SELECT
+            1,
+            2
+        FROM table_1 /* some comment */
+        """
+
+        res = get_source_tables(query, dialect="bigquery")
+
+        expected = ["table_1"]
+        assert res == expected

--- a/tests/sql_mock/test_table_mocks.py
+++ b/tests/sql_mock/test_table_mocks.py
@@ -110,7 +110,7 @@ def test_as_sql_input():
     ]
     sql_input = mock_table_instance.as_sql_input()
     expected = (
-        f"{mock_table_instance._sql_mock_meta.table_ref} AS (\n"
+        f"{mock_table_instance._sql_mock_meta.cte_name} AS (\n"
         "\tSELECT cast('1' AS Integer) AS col1, cast('value1' AS String) AS col2\n"
         "\tUNION ALL\n"
         "\tSELECT cast('2' AS Integer) AS col1, cast('value2' AS String) AS col2\n"
@@ -147,7 +147,7 @@ class TestToSqlModel:
         sql_model = mock_table.as_sql_input()
 
         expected_sql_model = (
-            "mock_test_table AS (\n"
+            f"{mock_table._sql_mock_meta.cte_name} AS (\n"
             "\tSELECT cast('1' AS Integer) AS col1, cast('hey' AS String) AS col2 FROM (SELECT 1) WHERE FALSE\n"
             ")"
         )
@@ -160,7 +160,7 @@ class TestToSqlModel:
         sql_model = mock_table.as_sql_input()
 
         expected_sql_model = (
-            "mock_test_table AS (\n"
+            f"{mock_table._sql_mock_meta.cte_name} AS (\n"
             "\tSELECT cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2\n"
             ")"
         )
@@ -173,7 +173,7 @@ class TestToSqlModel:
         sql_model = mock_table.as_sql_input()
 
         expected_sql_model = (
-            "mock_test_table AS (\n"
+            f"{mock_table._sql_mock_meta.cte_name} AS (\n"
             "\tSELECT cast('42' AS Integer) AS col1, cast('test_value' AS String) AS col2\n"
             "\tUNION ALL\n"
             "\tSELECT cast('100' AS Integer) AS col1, cast('another_value' AS String) AS col2\n"
@@ -185,6 +185,6 @@ class TestToSqlModel:
 def test_cte_name():
     mock_table_meta = TableMockMeta(table_ref='"my-project.schema.table_name"')
 
-    expected_cte_name = "my_project__schema__table_name"
+    expected_cte_name = "sql_mock__my_project__schema__table_name"
 
     assert mock_table_meta.cte_name == expected_cte_name

--- a/tests/test_table_mocks/test_generate_query.py
+++ b/tests/test_table_mocks/test_generate_query.py
@@ -1,4 +1,4 @@
-from textwrap import dedent
+import sqlglot
 
 from sql_mock.column_mocks import BaseColumnMock
 from sql_mock.table_mocks import BaseTableMock, table_meta
@@ -30,7 +30,7 @@ def test_generate_query_no_cte_provided(mocker):
     mock_table_instance = MockTestTable.from_dicts([])
     mock_table_instance._sql_mock_data.input_data = [mock_table_instance]
     original_query = f"SELECT * FROM {mock_table_instance._sql_mock_meta.table_ref}"
-    dummy_return_query = "SELECT foo FROM bar"
+    dummy_return_query = sqlglot.parse_one("SELECT foo FROM bar")
     mock_table_instance._sql_mock_data.rendered_query = original_query
 
     mocked_select_from_cte = mocker.patch("sql_mock.table_mocks.select_from_cte")
@@ -38,7 +38,7 @@ def test_generate_query_no_cte_provided(mocker):
         "sql_mock.table_mocks.replace_original_table_references", return_value=dummy_return_query
     )
 
-    expected_query_template_result = dedent(
+    expected_query_template_result = sqlglot.parse_one(
         f"""
     WITH {mock_table_instance._sql_mock_meta.cte_name} AS (
     \tSELECT cast('1' AS Integer) AS col1, cast('hey' AS String) AS col2 FROM (SELECT 1) WHERE FALSE
@@ -61,10 +61,13 @@ def test_generate_query_no_cte_provided(mocker):
     # Asserts
     mocked_select_from_cte.assert_not_called()
     mocked_replace_original_table_references.assert_called_once_with(
-        expected_query_template_result, mock_tables=[mock_table_instance], dialect=mock_table_instance._sql_dialect
+        query_ast=expected_query_template_result,
+        table_ref=mock_table_instance._sql_mock_meta.table_ref,
+        sql_mock_cte_name=mock_table_instance._sql_mock_meta.cte_name,
+        dialect=mock_table_instance._sql_dialect
     )
     # The final query should be equal to whatever is returned by `replace_original_table_references`
-    assert query == mocked_replace_original_table_references.return_value
+    assert query == mocked_replace_original_table_references.return_value.sql(pretty=True)
 
 
 def test_generate_query_cte_provided(mocker):
@@ -75,7 +78,7 @@ def test_generate_query_cte_provided(mocker):
     original_query = f"SELECT * FROM {mock_table_instance._sql_mock_meta.table_ref}"
     cte_to_select = "some_cte"
     cte_adjusted_query = f"SELECT * FROM {cte_to_select}"
-    dummy_return_query = "SELECT foo FROM bar"
+    dummy_return_query = sqlglot.parse_one("SELECT foo FROM bar")
     mock_table_instance._sql_mock_data.rendered_query = original_query
 
     mocked_select_from_cte = mocker.patch("sql_mock.table_mocks.select_from_cte", return_value=cte_adjusted_query)
@@ -83,7 +86,7 @@ def test_generate_query_cte_provided(mocker):
         "sql_mock.table_mocks.replace_original_table_references", return_value=dummy_return_query
     )
 
-    expected_query_template_result = dedent(
+    expected_query_template_result = sqlglot.parse_one(
         f"""
     WITH {mock_table_instance._sql_mock_meta.cte_name} AS (
     \tSELECT cast('1' AS Integer) AS col1, cast('hey' AS String) AS col2 FROM (SELECT 1) WHERE FALSE
@@ -104,13 +107,17 @@ def test_generate_query_cte_provided(mocker):
 
     # Asserts
     mocked_select_from_cte.assert_called_once_with(
-        original_query, cte_to_select, sql_dialect=MockTestTable._sql_dialect
+        original_query, cte_to_select, sql_dialect=mock_table_instance._sql_dialect
     )
+    # replace_original_table_references should be called once since we have a single input table
     mocked_replace_original_table_references.assert_called_once_with(
-        expected_query_template_result, mock_tables=[mock_table_instance], dialect=mock_table_instance._sql_dialect
+        query_ast=expected_query_template_result,
+        table_ref=mock_table_instance._sql_mock_meta.table_ref,
+        sql_mock_cte_name=mock_table_instance._sql_mock_meta.cte_name,
+        dialect=mock_table_instance._sql_dialect
     )
     # The final query should be equal to whatever is returned by `replace_original_table_references`
-    assert query == mocked_replace_original_table_references.return_value
+    assert query == mocked_replace_original_table_references.return_value.sql(pretty=True)
 
 
 def test_generate_query_sql_has_semicolon():


### PR DESCRIPTION
# Problem Context

We currently cannot mock CTEs which creates issues with dbt ephemeral models. 
Being able to mock CTEs also allows us to create even more granular unit tests

# What changed

Added functionality to mock CTEs

Take an example:
Now you can mock only `cte_1` without the need of mocking `some_table` and `another_table`:

```python
        @table_meta(table_ref="cte_1")
        class Cte1Mock(BaseTableMock):
            pass

        query = """
        WITH cte_1 AS (
            SELECT * 
            FROM some_table
           LEFT JOIN another_table USING(id)
        )

        SELECT * FROM cte_1
        """
```