### PR TITLE
Fix: Replace table prefix as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Add default target path for dbt
+* Improve replacement of tables (also taking into account missing alias)
 
 ## [0.6.0]
 

--- a/src/sql_mock/helpers.py
+++ b/src/sql_mock/helpers.py
@@ -55,7 +55,7 @@ def _replace_table_ref_in_columns(
         if col_table.name == ref_table.name:
             col.set("table", new_ref)
             # Make sure to remove the schema and db from the col table reference
-            # to fully exchange it wit the provided table ref
+            # to fully exchange it with the provided table ref
             col.set("schema", None)
             col.set("db", None)
     return query_ast

--- a/src/sql_mock/helpers.py
+++ b/src/sql_mock/helpers.py
@@ -2,8 +2,8 @@ from collections import Counter
 from typing import TYPE_CHECKING, List
 
 import sqlglot
+from sqlglot.expressions import replace_tables, to_table
 from sqlglot.optimizer.eliminate_ctes import eliminate_ctes
-from sqlglot.expressions import replace_tables
 from sqlglot.optimizer.scope import build_scope
 
 from sql_mock.exceptions import ValidationError
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 def get_keys_from_list_of_dicts(data: list[dict]) -> set[str]:
     return set(key for dictionary in data for key in dictionary.keys())
+
 
 def remove_cte_from_query(query_ast: sqlglot.Expression, cte_name: str) -> sqlglot.Expression:
     """
@@ -29,7 +30,40 @@ def remove_cte_from_query(query_ast: sqlglot.Expression, cte_name: str) -> sqlgl
             cte.pop()
     return query_ast
 
-def replace_original_table_references(query_ast: sqlglot.Expression, table_ref: str, sql_mock_cte_name: str, dialect: str) -> sqlglot.Expression:
+
+def _replace_table_ref_in_columns(
+    query_ast: sqlglot.Expression, table_ref: str, new_ref: str, dialect: str
+) -> sqlglot.Expression:
+    """
+    Replace original table reference with a new ref
+
+    Args:
+        query_ast (str): Original SQL query - parsed by sqlglot
+        table_ref (str): Table ref to be replaced
+        new_ref (str): Name of the new table ref
+    """
+    ref_table = to_table(table_ref, dialect=dialect)
+
+    root = build_scope(query_ast)
+    cols_in_query = [col for scope in root.traverse() for col in scope.columns]
+    for col in cols_in_query:
+        if not col.table:
+            continue
+        # For column replacement we simplify the comparison to the table name
+        # which is why we cast the col.table string to a table object
+        col_table = to_table(col.table, dialect=dialect)
+        if col_table.name == ref_table.name:
+            col.set("table", new_ref)
+            # Make sure to remove the schema and db from the col table reference
+            # to fully exchange it wit the provided table ref
+            col.set("schema", None)
+            col.set("db", None)
+    return query_ast
+
+
+def replace_original_table_references(
+    query_ast: sqlglot.Expression, table_ref: str, sql_mock_cte_name: str, dialect: str
+) -> sqlglot.Expression:
     """
     Replace original table reference with sql mock cte name to point them to the mocked data
 
@@ -39,6 +73,9 @@ def replace_original_table_references(query_ast: sqlglot.Expression, table_ref: 
         sql_mock_cte_name (str): Name of the CTE that will contain the mocked data
         dialect (str): The SQL dialect to use for parsing the query
     """
+    query_ast = _replace_table_ref_in_columns(
+        query_ast=query_ast, table_ref=table_ref, new_ref=sql_mock_cte_name, dialect=dialect
+    )
     return replace_tables(expression=query_ast, mapping={table_ref: sql_mock_cte_name}, dialect=dialect)
 
 
@@ -145,7 +182,11 @@ def validate_all_input_mocks_for_query_provided(query: str, input_mocks: List["B
         input_mocks (List[BaseTableMock]): The input mocks that are provided
         dialect (str): The SQL dialect to use for parsing the query
     """
-    provided_table_refs = [table_mock._sql_mock_meta.table_ref for table_mock in input_mocks if hasattr(table_mock._sql_mock_meta, "table_ref")]
+    provided_table_refs = [
+        table_mock._sql_mock_meta.table_ref
+        for table_mock in input_mocks
+        if hasattr(table_mock._sql_mock_meta, "table_ref")
+    ]
     ast = sqlglot.parse_one(query, dialect=dialect)
 
     # In case the table_ref is a CTE, we need to remove it from the query


### PR DESCRIPTION
## Problem context

SQLMock currently has issues if the table name is used as a prefix to columns in the query and is not able to properly replace it.

Closes: https://github.com/DeepLcom/sql-mock/issues/43

## What changed

* Additionally to purely replace the tables, we loop over the columns as well to replace the references there as well

## Testing

I added a new test but also tested the case provided in the issue (with a small correction that it returns the expected value):


```python
from sql_mock.clickhouse.table_mocks import ClickHouseTableMock
from sql_mock.table_mocks import table_meta
import sql_mock.clickhouse.column_mocks as col

QUERY_SIMPLE = """
SELECT col1
FROM bee as b
JOIN a ON a.col1 = b.col1
"""

@table_meta(table_ref="a")
class aMock(ClickHouseTableMock):
    col1 = col.String(default="1")

@table_meta(table_ref="bee")
class bMock(ClickHouseTableMock):
    col1 = col.String(default="1")

@table_meta(query=QUERY_SIMPLE)
class BugTableMock(ClickHouseTableMock):
    col1 = col.String(default="1")

def test_working():
    input_table_mock_1 = aMock([{}])
    input_table_mock_2 = bMock([{}])

    res = BugTableMock.from_mocks(input_data=[
        input_table_mock_1, input_table_mock_2])

    expected = [{'col1': '1'}]
    res.assert_equal(expected)

```