### PR TITLE
Add linting to Makefile

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -36,15 +36,10 @@ jobs:
       run: |
         poetry install --all-extras
     - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=119 --statistics --ignore E203,E266,E501,W503
+      run: make lint
     - name: Test with pytest
       env:
         SQL_MOCK_CLICKHOUSE_HOST: 127.0.0.1
         SQL_MOCK_CLICKHOUSE_PORT: 8123
         SQL_MOCK_CLICKHOUSE_USER: default
-      run: |
-        poetry run pytest tests/
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ SHELL := /bin/bash
 help: ## Show all available commands
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-13s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST);
 
+.PHONY: lint
+lint: ## Lint code with flake8
+	poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # stop the build if there are Python syntax errors or undefined names
+	poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=119 --statistics --ignore E203,E266,E501,W503 # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+
 .PHONY: test
 test: ## Run test pipeline
 	poetry run pytest tests/

--- a/src/sql_mock/bigquery/column_mocks.py
+++ b/src/sql_mock/bigquery/column_mocks.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from sql_mock.column_mocks import BaseColumnMock
 
 
@@ -7,7 +8,7 @@ class BigQueryColumnMock(BaseColumnMock):
 
 
 class Boolean(BigQueryColumnMock):
-    dtype = 'Boolean'
+    dtype = "Boolean"
 
 
 class Int(BigQueryColumnMock):
@@ -33,7 +34,7 @@ class Decimal(BigQueryColumnMock):
 
 
 class Timestamp(BigQueryColumnMock):
-    dtype = 'Timestamp'
+    dtype = "Timestamp"
 
 
 class Array(BigQueryColumnMock):
@@ -43,7 +44,7 @@ class Array(BigQueryColumnMock):
         self,
         inner_type: BigQueryColumnMock,
         default: Any,
-        nullable: bool=False,
+        nullable: bool = False,
     ) -> None:
         self.dtype = f"Array<{inner_type.dtype}>"
         super().__init__(default, nullable)

--- a/src/sql_mock/clickhouse/column_mocks.py
+++ b/src/sql_mock/clickhouse/column_mocks.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from sql_mock.column_mocks import BaseColumnMock
 
 
@@ -50,7 +51,7 @@ class Array(ClickhouseColumnMock):
         self,
         inner_type: ClickhouseColumnMock,
         default: Any,
-        nullable: bool=False,
+        nullable: bool = False,
     ) -> None:
         self.dtype = f"Array({inner_type.dtype})"
         super().__init__(default, nullable)

--- a/tests/sql_mock/redshift/test_column_mocks.py
+++ b/tests/sql_mock/redshift/test_column_mocks.py
@@ -1,4 +1,4 @@
-from sql_mock.redshift.column_mocks import RedshiftColumnMock, DECIMAL
+from sql_mock.redshift.column_mocks import DECIMAL, RedshiftColumnMock
 
 
 def test_init_nullable():
@@ -45,4 +45,3 @@ class TestDecimalColumn:
         assert decimal_col.dtype == "DECIMAL(10, 2)"
         assert decimal_col.default is None
         assert decimal_col.nullable
-

--- a/tests/test_table_mocks/test_assert_equal.py
+++ b/tests/test_table_mocks/test_assert_equal.py
@@ -47,7 +47,7 @@ _assert_equal_successful_test_cases = [
             id="Matching data - Missing keys ignored - Order ignored - including mixed None and int values",
         ),
         pytest.param(
-            [{"name":None, "age": 25, "city": "New York"}, {"name": "Bob", "age": 30, "city": "Munich"}],  # data
+            [{"name": None, "age": 25, "city": "New York"}, {"name": "Bob", "age": 30, "city": "Munich"}],  # data
             [{"name": None, "age": 25}, {"name": "Bob", "age": 30}],  # expected_data
             True,  # ignore_missing_keys
             True,  # ignore_order


### PR DESCRIPTION
This commits will extend the `Makefile` introduced in #54 to include a `lint` command and the `test-package.yml` GitHub actions template updated to make use of the `make` commands. Additionally, linting will be applied to the codebase.